### PR TITLE
Option to force non xc8-cc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,12 @@ in ``CMakeLists.txt`` as above or on the CMake command line like so::
 
     cmake -DMICROCHIP_MCU=PIC24FJ256GB004 .
 
+If you wish to use the 'legacy' xc8 compiler (`xc8`) over the `clang`-based
+version (`xc8-cc`), this can be achieved by telling CMake to 'force' the use of
+non-`cc` version::
+
+    cmake -DMICROCHIP_XC8_FORCE_NON_CC:BOOL=ON .
+
 Copying
 =======
 


### PR DESCRIPTION
I am currently working with some xc8 code that _does not_ compile with `xc8-cc`, but does with `xc8`. This PR adds a CMake ~variable~ option (`MICROCHIP_XC8_FORCE_NON_CC`) that allows the user to force the non-`cc` compiler.

To use it, add

```
set(MICROCHIP_XC8_FORCE_NON_CC ON CACHE BOOL "" FORCE)
```

to the top of your CMakeLists.txt, or provide it on the command line:

```
-DMICROCHIP_XC8_FORCE_NON_CC:BOOL=ON
```
